### PR TITLE
fix and remove MusicDrawer useless style

### DIFF
--- a/src/MusicDrawer/index.js
+++ b/src/MusicDrawer/index.js
@@ -237,7 +237,7 @@ const ApplePlaylist = () => {
       <TabBar
         as={animated.div}
         style={{
-          opacity: y.interpolate([stops], [1, 0]),
+          opacity: y.interpolate(stops, [1, 0]),
           transform: y.interpolate(y => {
             const translateY = rangeMap(stops, [0, 60], y)
             return `translate3D(0px, ${translateY}px, 0)`

--- a/src/MusicDrawer/styled-components.js
+++ b/src/MusicDrawer/styled-components.js
@@ -46,7 +46,6 @@ export const Handle = styled.div`
   height: 0.4rem;
   background-color: hsla(0, 0%, 0%, 0.1);
   border-radius: 9px;
-  position: absolute;
   top: 1rem;
   position: absolute;
   left: 50%;
@@ -72,7 +71,6 @@ export const NowPlayingDrawer = styled.div`
 
 export const ClosedControlsContainer = styled.div`
   position: absolute;
-  right: 0;
   top: 1.7rem;
   right: 12px;
 
@@ -133,7 +131,6 @@ export const NowPlayingImage = styled.img.attrs({
   transform-origin: 0 0;
   display: block;
   margin-right: 1rem;
-  position: relative;
   z-index: 1;
   transform: scale(0.3333);
   position: absolute;


### PR DESCRIPTION
# Purpose
- fix `MusicDrawer` invalid style
- remove `MusicDrawer` useless duplicate style

## about `/MusicDrawer/index.js`
I'm not fully understand `func y.interpolate`  

but I think this return is **NOT CORRECT** (and devtool also warning **invalid value**)

```js
{
  opacity: y.interpolate([stops], [1, 0])
}
```

![image](https://user-images.githubusercontent.com/22259196/79143041-16b77900-7def-11ea-878a-a07e90d8af77.png)  
![image](https://user-images.githubusercontent.com/22259196/79143009-069f9980-7def-11ea-9abb-04ca1b7f0583.png)  

## about `/MusicDrawer/styled-components.js
- remove **duplicate style**
  -  `ClosedControlsContainer` => I think you want set `right = 12px` **,NOT 0px**, so remove it.  


  **Thank you for your awesome talk and DEMO, I still learning from this DEMO**
