### PR TITLE
fix Notification style, remove Flipper useless function arg

### DIFF
--- a/src/Flipper.js
+++ b/src/Flipper.js
@@ -26,7 +26,7 @@ class Flipper {
     // we need to figure out what the "real" final state is without any residual transform from an interrupted animation
     el.style.transform = ""
 
-    const after = this.measure(id, true)
+    const after = this.measure(id)
     const before = this.positions[id]
     const scaleX = before.width / after.width
     const scaleY = before.height / after.height

--- a/src/Notification/styled-components.js
+++ b/src/Notification/styled-components.js
@@ -9,7 +9,7 @@ export const StyledNotification = styled.div`
   padding: 0.5rem 2rem 0.5rem 2rem;
   background-color: #171226;
   color: white;
-  box-shadow: 0 0 0 1px transparent, 0 3px 10px #00000026;
+  box-shadow: 0 0 0 1px transparent, 0 3px 10px #000026;
   user-select: none;
   min-width: 70vw;
   pointer-events: all;


### PR DESCRIPTION
# Purpose
- fix `Notification` style
- remove `Flipper.js` 's function useless arg

## about `Notification`
### before
![image](https://user-images.githubusercontent.com/22259196/79561228-94bf9c80-80db-11ea-962b-f1150aad81d8.png)

### after
![image](https://user-images.githubusercontent.com/22259196/79561248-9ab57d80-80db-11ea-9e4b-4eaa2d236ea8.png)

## about `Flipper.js`
`function measure` did not use **second arg**, so I think we can remove it.

```js
  measure(id) {
    const el = this.getEl(id)
    if (el) return el.getBoundingClientRect()
  }
```
